### PR TITLE
Replace shebang for portability sake

### DIFF
--- a/gh-contribute
+++ b/gh-contribute
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 repo="vilmibm/gh-contribute"

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # TODO ARM support. figure out mapping to uname -m output.


### PR DESCRIPTION
The shebang used in gh-screensaver and release.sh scripts (#!/bin/bash)
has greater chance to fail (as it does on NixOS, for example).

https://en.wikipedia.org/w/index.php?title=Shebang_(Unix)&oldid=878552871#Portability